### PR TITLE
PSE-4073: Added support for videos in Firefox

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,8 +15,8 @@ $(document).ready(function() {
         navigator.userAgent
     );
 
-    if (!isTouch && $('body').attr('data-video').length) {
-        BV = new $.BigVideo({ forceAutoplay: isTouch });
+    if ($('body').attr('data-video').length) {
+        BV = new $.BigVideo({ forceAutoplay: isTouch, useFlashForFirefox: false });
         BV.init();
         BV.show($('body').attr('data-video'), { ambient: true });
         BV.getPlayer().on('durationchange', function() {


### PR DESCRIPTION
This PR adds support for background videos on Firefox and mobile browsers.

[QA Doc](https://docs.google.com/document/d/1uiSVISftRhg_fBj8PKbBvaDDW0iEn8nbSsUk-ukSqXM/edit?usp=sharing)